### PR TITLE
(refs #12) Statistics update after last placement

### DIFF
--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/play/GameEngine.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/play/GameEngine.java
@@ -1680,6 +1680,7 @@ public class GameEngine {
 		if(endTime == 0) {
 			endTime = System.nanoTime();
 			statistics.gamerate = (float)(replayTimer / (0.00000006*(endTime - startTime)));
+                        statistics.update();
 		}
 		gameActive = false;
 		timerActive = false;


### PR DESCRIPTION
See #12

After the endTime is set, the statistics are updated one last time to take the last placed block into account.

As a result ppm and pps values (the ones that need `totalPieceLocked`) will reflect the real value.