### PR TITLE
Add CI and artifact support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+version: '{build}'
+os: 
+  - Windows Server 2012
+  - ubuntu
+install:
+  - cmd: java -version
+  - sh: sudo apt-get update
+  - sh: sudo apt-get install icedtea-netx -y
+  - sh: sudo cp /usr/share/icedtea-web/netx.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/
+  - sh: sudo mv /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/netx.jar /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/javaws.jar
+  - sh: export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+before_build:
+  - cd nullpomino-parent
+build_script:
+  - mvn install
+artifacts:
+  - path: nullpomino-run/target/install/
+    type: zip


### PR DESCRIPTION
CI support is done through [Appveyor](https://www.appveyor.com/), which allows builds from both Linux and Windows, as well as packaging and storage of artifacts (up to six months, but can be configured for longer). Once the appveyor account is set up and the repository is linked, every commit and pull request will be run by appveyor.