### PR TITLE
Checkboxes in the Option Screens

### DIFF
--- a/nullpomino-core/src/main/java/mu/nu/nullpo/util/GeneralUtil.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/util/GeneralUtil.java
@@ -77,8 +77,8 @@ public class GeneralUtil {
 	 * @return ○ if b is true, × if b is false
 	 */
 	public static String getOorX(boolean b) {
-		if(b == true) return "c";
-		return "e";
+		if(b == true) return "g";
+		return "f";
 	}
 
 	/**


### PR DESCRIPTION
I found the checkboxes in the option screens to be confusing since both an open O and and X can mean negative/false/disabled/unchecked/etc. Changed characters used to open/closed squares (like checkboxes in most GUIs) which is hopefully more obvious.