### PR TITLE
Fixed the Settings menu only appearing the first time.

### DIFF
--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/play/GameEngine.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/play/GameEngine.java
@@ -42,6 +42,7 @@ import mu.nu.nullpo.game.component.RuleOptions;
 import mu.nu.nullpo.game.component.SpeedParam;
 import mu.nu.nullpo.game.component.Statistics;
 import mu.nu.nullpo.game.component.WallkickResult;
+import mu.nu.nullpo.game.subsystem.mode.AbstractMode;
 import mu.nu.nullpo.game.subsystem.ai.DummyAI;
 import mu.nu.nullpo.game.subsystem.wallkick.Wallkick;
 import mu.nu.nullpo.util.GeneralUtil;
@@ -959,6 +960,8 @@ public class GameEngine {
 	 */
 	public void resetStatc() {
 		for(int i = 0; i < statc.length; i++) statc[i] = 0;
+		if (owner.mode instanceof AbstractMode)
+			((AbstractMode) owner.mode).resetCounters();
 	}
 
 	/**

--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/AbstractMode.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/AbstractMode.java
@@ -189,6 +189,10 @@ public abstract class AbstractMode implements GameMode {
 		receiver = engine.owner.receiver;
 	}
 
+	public void resetCounters() {
+		menuTime = 0;
+	}
+	
 	public void renderARE(GameEngine engine, int playerID) {
 	}
 


### PR DESCRIPTION
If a new game was started, either by Pause->Retry or by quitting to main menu first, the Settings menu would not appear before the game. It would only appear the first time. AbstractMode.menuTime was not being reset to 0.

The fix below is the only way I could see to fix it without having to modify ALL of the Mode classes.