### PR TITLE
Fix a copypaste error in the new menu code

### DIFF
--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/GradeMania2Mode.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/GradeMania2Mode.java
@@ -303,7 +303,7 @@ public class GradeMania2Mode extends AbstractMode {
 		always20g = new OnOffMenuItem("always20g", "20G MODE", EventReceiver.COLOR_BLUE, false);
 		lvstopse = new OnOffMenuItem("lvstopse", "LVSTOPSE", EventReceiver.COLOR_BLUE, false);
 		big = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, false);
-		showsectiontime = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, false);
+		showsectiontime = new OnOffMenuItem("showsectiontime", "SHOW STIME", EventReceiver.COLOR_BLUE, false);
 		menu.add(startlevel);
 		menu.add(alwaysghost);
 		menu.add(always20g);

--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/GradeManiaMode.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/GradeManiaMode.java
@@ -217,8 +217,8 @@ public class GradeManiaMode extends AbstractMode {
 		alwaysghost = new OnOffMenuItem("alwaysghost", "FULL GHOST", EventReceiver.COLOR_BLUE, false);
 		always20g = new OnOffMenuItem("always20g", "20G MODE", EventReceiver.COLOR_BLUE, false);
 		lvstopse = new OnOffMenuItem("lvstopse", "LVSTOPSE", EventReceiver.COLOR_BLUE, false);
-		showsectiontime = new OnOffMenuItem("showsectiontime", "SHOW STIME", EventReceiver.COLOR_BLUE, false);
 		big = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, false);
+		showsectiontime = new OnOffMenuItem("showsectiontime", "SHOW STIME", EventReceiver.COLOR_BLUE, false);
 		menu.add(startlevel);
 		menu.add(alwaysghost);
 		menu.add(always20g);

--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/PhantomManiaMode.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/PhantomManiaMode.java
@@ -232,7 +232,7 @@ public class PhantomManiaMode extends AbstractMode {
 		};
 		lvstopse = new OnOffMenuItem("lvstopse", "LVSTOPSE", EventReceiver.COLOR_BLUE, false);
 		big = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, false);
-		showsectiontime = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, true);
+		showsectiontime = new OnOffMenuItem("showsectiontime", "SHOW STIME", EventReceiver.COLOR_BLUE, false);
 		menu.add(startlevel);
 		menu.add(lvstopse);
 		menu.add(showsectiontime);

--- a/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/SpeedManiaMode.java
+++ b/nullpomino-core/src/main/java/mu/nu/nullpo/game/subsystem/mode/SpeedManiaMode.java
@@ -207,7 +207,7 @@ public class SpeedManiaMode extends AbstractMode {
 		};
 		lvstopse = new OnOffMenuItem("lvstopse", "LVSTOPSE", EventReceiver.COLOR_BLUE, false);
 		big = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, false);
-		showsectiontime = new OnOffMenuItem("big", "BIG", EventReceiver.COLOR_BLUE, true);
+		showsectiontime = new OnOffMenuItem("showsectiontime", "SHOW STIME", EventReceiver.COLOR_BLUE, false);
 		lv500torikan = new TimeMenuItem("lv500torikan", "LV500LIMIT", EventReceiver.COLOR_BLUE, 12300, 0, 72000) {
 			public String getValueString() {
 				return (value == 0) ? "NONE" : GeneralUtil.getTime(value);


### PR DESCRIPTION
Big mode and showsectiontime options were given the same name, so the setting
did not stick (had to be re-enabled every play). In addition, the menu in e.g.
Grade Mania 2 said "BIG" twice. Finally, because of the settings having the
same name, big mode replays would play back as though they were not big mode.

Also changes the Grade Mania menu item order to be consistent with the other modes.